### PR TITLE
BF-64: set Stack `clipBehavior` to `Clip.none`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0-nullsafety+1
+
+* Fixed issue with current height slider label being clipped
+
 ## 1.4.0-nullsafety
 
 * Initial release with null safety

--- a/lib/height_slider.dart
+++ b/lib/height_slider.dart
@@ -73,7 +73,7 @@ class _HeightSliderState extends State<HeightSlider> {
           onVerticalDragStart: this._onDragStart,
           onVerticalDragUpdate: this._onDragUpdate,
           child: Stack(
-            clipBehavior: Clip.hardEdge,
+            clipBehavior: Clip.none,
             children: <Widget>[
               _drawPersonImage(constraints.maxWidth),
               _drawSlider(),
@@ -170,13 +170,14 @@ class _HeightSliderState extends State<HeightSlider> {
     );
   }
 
-  Widget _drawPersonImage(double maxHeight) {
+  Widget _drawPersonImage(double maxWidth) {
     double personImageHeight = _sliderPosition + 12.0;
     if (widget.personImagePath == null) {
       return Align(
         alignment: Alignment.bottomCenter,
         child: Container(
-          width: maxHeight,
+          width: maxWidth,
+          height: personImageHeight,
           child: SvgPicture.asset(
             "images/person.svg",
             package: 'height_slider',
@@ -191,7 +192,8 @@ class _HeightSliderState extends State<HeightSlider> {
     return Align(
       alignment: Alignment.bottomCenter,
       child: Container(
-        width: maxHeight,
+        width: maxWidth,
+        height: personImageHeight,
         child: SvgPicture.asset(
           widget.personImagePath!,
           fit: BoxFit.contain,

--- a/lib/src/height_slider_internal.dart
+++ b/lib/src/height_slider_internal.dart
@@ -25,9 +25,10 @@ class HeightSliderInternal extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           SliderLabel(
-              height: this.height,
-              unit: this.unit,
-              currentHeightTextColor: this.currentHeightTextColor),
+            height: this.height,
+            unit: this.unit,
+            currentHeightTextColor: this.currentHeightTextColor,
+          ),
           Row(
             children: <Widget>[
               SliderCircle(sliderCircleColor: this.sliderCircleColor),


### PR DESCRIPTION
Fixes issue with current height slider label being clipped